### PR TITLE
 monitor.isOver({ shallow: true }) support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-dnd-touch-backend",
-  "version": "0.2.7",
+  "version": "0.2.8",
   "description": "Touch backend for react-dnd",
   "main": "dist/Touch.js",
   "scripts": {


### PR DESCRIPTION
This pull request is an attempt to fix issues #30 and #14.

The hover action from dnd-core expects an array of target IDs in an order corresponding to the nested DropTargets.  Following the implementation in the dnd HTML5 backend, the touch backend now depends on the bubble and capture events associated with the touchmove and mousemove events to create the array of target ID's in the order expected by the hover action instead of getBoundingClientRect() and the current mouse position.

A consequence to using this approach, however, is that a DragLayer implementation must not prevent the mouse/touch events from firing on the drop targets.  This can be accomplished by following the React DnD recommendation to set the css property mouse-events to 'none' when implementing a custom DragLayer https://gaearon.github.io/react-dnd/docs-drag-layer.html.

Awesome job on this library!  Please let me know if, in my ignorance, I broke something.
cheers!