### PR TITLE
Fix issues surrounding 'touchmove' event listener

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -190,6 +190,11 @@ export class TouchBackend {
          * Attaching the event listener to the body so that touchmove will work while dragging over multiple target elements.
          */
         this.addEventListener(document.querySelector('body'), 'move', handleMove);
+
+
+        return () => {
+            this.removeEventListener(document.querySelector('body'), 'move', handleMove);
+        };
     }
 
     getSourceClientOffset (sourceId) {

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -160,14 +160,36 @@ export class TouchBackend {
     }
 
     connectDropTarget (targetId, node) {
+        const handleMove = (e) => {
+            let coords;
 
-        const handleMove = (e) => this.handleMove(e, targetId);
+            /**
+             * Grab the coordinates for the current mouse/touch position
+             */
+            switch (e.type) {
+            case eventNames.mouse.move:
+                coords = { x: e.clientX, y: e.clientY };
+                break;
 
-        this.addEventListener(node, 'move', handleMove);
+            case eventNames.touch.move:
+                coords = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+                break;
+            default:
+            }
 
-        return () => {
-            this.removeEventListener(node, 'move', handleMove);
+            /**
+             * Use the coordinates to grab the element the drag ended on.
+             * If the element's parent is the same as the target node then we have hit a drop target and can handle the move.
+             */
+            if (document.elementFromPoint(coords.x, coords.y).parentNode === node) {
+                return this.handleMove(e, targetId);
+            }
         };
+
+        /**
+         * Attaching the event listener to the body so that touchmove will work while dragging over multiple target elements.
+         */
+        this.addEventListener(document.querySelector('body'), 'move', handleMove);
     }
 
     getSourceClientOffset (sourceId) {


### PR DESCRIPTION
Pull request to fix some issues surrounding 'touchmove' event listener.

**The problem:**
The 'touchmove' event is only triggered when over the original element from where you started the touch. This means that when trying to touch-drag something onto another element it will not detect the dropTarget due to the 'touchmove' event not being triggered.

**The fix:**
I have updated the 'connectDropTarget' function to add an event listener to the body for any 'mousemove' and 'touchmove' events. It will grab the coordinates of the users current drag position and then find which DOM element the user is over. If the element matches a dropTarget it will handle the move as before.