### PR TITLE
Improving connectDropTarget

### DIFF
--- a/examples/dropTarget/index.html
+++ b/examples/dropTarget/index.html
@@ -1,0 +1,48 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style type="text/css">
+            .source, .target {
+                margin: 20px;
+                padding: 10px;
+                text-align: center;
+                font-size: 20px;
+            }
+            .source, .source-preview {
+                background: #c7c7c7;
+                width: 100px;
+                height: 100px;
+                cursor: pointer;
+            }
+            .source-preview {
+                background: #888888;
+                opacity: 0.5;
+                position: fixed;
+                z-index: 100;
+                left: 0;
+                top: 0;
+                opacity: 1;
+                transition: none;
+                pointer-events: none;
+                -webkit-touch-callout: none;
+            }
+            .target {
+                background: #eeeeee;
+                width: 300px;
+                height: 300px;
+            }
+            .nested-child {
+                padding: 10px;
+                margin: 50px 10px;
+                background-color: #ffffff;
+            }
+        </style>
+    </head>
+    <body>
+        <div id="app"></div>
+        <script type="text/javascript" src="./main.browserified.js"></script>
+    </body>
+</html>

--- a/examples/dropTarget/js/DragPreview.jsx
+++ b/examples/dropTarget/js/DragPreview.jsx
@@ -1,0 +1,41 @@
+'use strict';
+
+import React, { Component, PropTypes } from 'react';
+import DragLayer from 'react-dnd/lib/DragLayer';
+
+function collect (monitor) {
+    return {
+        sourceOffset: monitor.getSourceClientOffset()
+    };
+}
+
+class DragPreview extends Component {
+    getLayerStyles() {
+        const { sourceOffset } = this.props;
+
+        return {
+            transform: sourceOffset ? `translate(${sourceOffset.x}px, ${sourceOffset.y}px)` : ''
+        };
+    }
+
+    render () {
+        const { isDragging } = this.props;
+        if (!isDragging) { return null; };
+
+        return (
+            <div className="source-preview" style={this.getLayerStyles()}>
+                Dragging
+            </div>
+        );
+    }
+}
+
+DragPreview.propTypes = {
+    isDragging: PropTypes.bool,
+    sourceOffset: PropTypes.shape({
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired
+    })
+};
+
+export default DragLayer(collect)(DragPreview);

--- a/examples/dropTarget/js/Source.jsx
+++ b/examples/dropTarget/js/Source.jsx
@@ -1,0 +1,42 @@
+'use strict';
+
+import React, { Component, PropTypes } from 'react';
+import DragSource from 'react-dnd/lib/DragSource';
+import DragPreview from './DragPreview.jsx';
+
+const dragSource = {
+    beginDrag (props) {
+        return props;
+    }
+};
+
+function collect(connect, monitor) {
+    return {
+        connectDragSource: connect.dragSource(),
+        connectDragPreview: connect.dragPreview(),
+        isDragging: monitor.isDragging()
+    };
+}
+
+class Source extends Component {
+    render () {
+        const {
+            connectDragSource
+        } = this.props;
+
+        return connectDragSource(
+            <div className="source">
+                <DragPreview {...this.props} />
+                Drag me!
+            </div>
+        );
+    }
+}
+
+Source.PropTypes = {
+    isDragging: PropTypes.bool.isRequired,
+    connectDragSource: PropTypes.func.isRequired,
+    connectDragPreview: PropTypes.func.isRequired
+};
+
+export default DragSource('draggable-item', dragSource, collect)(Source);

--- a/examples/dropTarget/js/Target.jsx
+++ b/examples/dropTarget/js/Target.jsx
@@ -1,0 +1,39 @@
+'use strict';
+
+import React, { Component, PropTypes } from 'react';
+import DropTarget from 'react-dnd/lib/DropTarget';
+
+const dragTarget = {
+    drop(props, monitor, component) {
+        console.log('dropped on target');
+    }
+};
+
+function collect(connect, monitor) {
+    return {
+        connectDropTarget: connect.dropTarget(),
+        isOver: monitor.isOver()
+    };
+}
+
+class Target extends Component {
+    render () {
+        const {
+            connectDropTarget
+        } = this.props;
+
+        return connectDropTarget(
+            <div className="target">
+                Drop here!
+                <div className="nested-child">Nested Child</div>
+            </div>
+        );
+    }
+}
+
+Target.PropTypes = {
+    connectDropTarget: PropTypes.func.isRequired,
+    isOver: PropTypes.bool.isRequired
+};
+
+export default DropTarget('draggable-item', dragTarget, collect)(Target);

--- a/examples/dropTarget/js/index.jsx
+++ b/examples/dropTarget/js/index.jsx
@@ -1,0 +1,22 @@
+'use strict';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+import { default as Touch } from '../../../src/Touch';
+import DragDropContext from 'react-dnd/lib/DragDropContext';
+import Source from './Source.jsx';
+import Target from './Target.jsx';
+
+class App extends React.Component {
+    render () {
+        return (
+            <div>
+                <Source />
+                <Target />
+            </div>
+        );
+    }
+}
+
+App = DragDropContext(Touch({ enableMouseEvents: true }))(App);
+ReactDOM.render(<App />, document.getElementById('app'));

--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -13,11 +13,16 @@ gulp.task('clean', () => {
     del.sync(['examples/*.browserified.js']);
 });
 
-// Compile example
+// Compile examples
 gulp.task('js-dev', js({
     src: './examples/js/index.jsx',
     destFilename: 'main.browserified.js',
     destFolder: './examples/'
+}));
+gulp.task('js-dev', js({
+    src: './examples/dropTarget/js/index.jsx',
+    destFilename: 'main.browserified.js',
+    destFolder: './examples/dropTarget/'
 }));
 
 // Compile scripts

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -174,14 +174,22 @@ export class TouchBackend {
             case eventNames.touch.move:
                 coords = { x: e.touches[0].clientX, y: e.touches[0].clientY };
                 break;
-            default:
             }
 
             /**
              * Use the coordinates to grab the element the drag ended on.
-             * If the element's parent is the same as the target node then we have hit a drop target and can handle the move.
+             * If the element is the same as the target node (or any of it's children) then we have hit a drop target and can handle the move.
              */
-            if (document.elementFromPoint(coords.x, coords.y).parentNode === node) {
+            let droppedOn = document.elementFromPoint(coords.x, coords.y);
+            let childMatch = false;
+
+            for (var i = 0; i < node.childNodes.length; i++) {
+                if (node.childNodes[i] === droppedOn) {
+                    childMatch = true;
+                };
+            }
+
+            if (droppedOn === node || childMatch) {
                 return this.handleMove(e, targetId);
             }
         };

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -190,6 +190,11 @@ export class TouchBackend {
          * Attaching the event listener to the body so that touchmove will work while dragging over multiple target elements.
          */
         this.addEventListener(document.querySelector('body'), 'move', handleMove);
+
+
+        return () => {
+            this.removeEventListener(document.querySelector('body'), 'move', handleMove);
+        };
     }
 
     getSourceClientOffset (sourceId) {

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -160,14 +160,36 @@ export class TouchBackend {
     }
 
     connectDropTarget (targetId, node) {
+        const handleMove = (e) => {
+            let coords;
 
-        const handleMove = (e) => this.handleMove(e, targetId);
+            /**
+             * Grab the coordinates for the current mouse/touch position
+             */
+            switch (e.type) {
+            case eventNames.mouse.move:
+                coords = { x: e.clientX, y: e.clientY };
+                break;
 
-        this.addEventListener(node, 'move', handleMove);
+            case eventNames.touch.move:
+                coords = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+                break;
+            default:
+            }
 
-        return () => {
-            this.removeEventListener(node, 'move', handleMove);
+            /**
+             * Use the coordinates to grab the element the drag ended on.
+             * If the element's parent is the same as the target node then we have hit a drop target and can handle the move.
+             */
+            if (document.elementFromPoint(coords.x, coords.y).parentNode === node) {
+                return this.handleMove(e, targetId);
+            }
         };
+
+        /**
+         * Attaching the event listener to the body so that touchmove will work while dragging over multiple target elements.
+         */
+        this.addEventListener(document.querySelector('body'), 'move', handleMove);
     }
 
     getSourceClientOffset (sourceId) {


### PR DESCRIPTION
**Small change to connectDropTarget**
Previous change wasn't robust enough as it was only looking at the parent of the element of which the drag end landed on. I've updated it to now check the drag end element against the dropTarget node and any of its children.

Also adding example files to demonstrate the change.
