### PR TITLE
Check if document is defined before checking if there is a elementsFromPoint method

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -24,7 +24,7 @@ function getEventClientOffset (e) {
 }
 
 // Polyfill for document.elementsFromPoint
-const elementsFromPoint = (document.elementsFromPoint || function (x,y) {
+const elementsFromPoint = ((document && document.elementsFromPoint) || function (x,y) {
     var elements = [], previousPointerEvents = [], current, i, d;
 
     // get all elements via elementFromPoint, and remove them from hit-testing in order


### PR DESCRIPTION
This fix the issue #60 

So it won't break if the library is parsed on the backend. 