### PR TITLE
Fallback to msElementsFromPoint because polyfill is incredibly slow in IE11

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -24,7 +24,7 @@ function getEventClientOffset (e) {
 }
 
 // Polyfill for document.elementsFromPoint
-const elementsFromPoint = ((typeof document !== 'undefined' && document.elementsFromPoint) || function (x,y) {
+const elementsFromPoint = ((typeof document !== 'undefined' && (document.elementsFromPoint || document.msElementsFromPoint)) || function (x,y) {
     var elements = [], previousPointerEvents = [], current, i, d;
 
     // get all elements via elementFromPoint, and remove them from hit-testing in order

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -24,7 +24,13 @@ function getEventClientOffset (e) {
 }
 
 // Polyfill for document.elementsFromPoint
-const elementsFromPoint = ((typeof document !== 'undefined' && (document.elementsFromPoint || document.msElementsFromPoint)) || function (x,y) {
+const elementsFromPoint = ((typeof document !== 'undefined' && document.elementsFromPoint) || function (x,y) {
+    
+    if (document.msElementsFromPoint) {
+        // msElementsFromPoint is much faster but returns a node-list, so convert it to an array
+        return Array.prototype.slice.call(document.msElementsFromPoint(x, y), 0);
+    }
+
     var elements = [], previousPointerEvents = [], current, i, d;
 
     // get all elements via elementFromPoint, and remove them from hit-testing in order


### PR DESCRIPTION
We upgraded from 0.3.3 to 0.3.11 and found Ie11 drag and drop became unusable.. incredibly slow and it didn't seem to detect the drop.

This change fixes both those problems.

Not sure what your browser support is, but you could also consider not providing a polyfill too.

cc @JoaoMosmann @longlho 

Would appreciate a quick merge.