### PR TITLE
Check that events exist before adding/removing handlers.

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -25,7 +25,7 @@ function getEventClientOffset (e) {
 
 // Polyfill for document.elementsFromPoint
 const elementsFromPoint = ((typeof document !== 'undefined' && document.elementsFromPoint) || function (x,y) {
-    
+
     if (document.msElementsFromPoint) {
         // msElementsFromPoint is much faster but returns a node-list, so convert it to an array
         return Array.prototype.slice.call(document.msElementsFromPoint(x, y), 0);
@@ -202,7 +202,11 @@ export class TouchBackend {
         const options = supportsPassive ? {capture, passive: false} : capture;
 
         this.listenerTypes.forEach(function (listenerType) {
-            subject.addEventListener(eventNames[listenerType][event], handler, options);
+            const evt = eventNames[listenerType][event];
+
+            if (evt) {
+                subject.addEventListener(evt, handler, options);
+            }
         });
     }
 
@@ -210,7 +214,11 @@ export class TouchBackend {
         const options = supportsPassive ? {capture, passive: false} : capture;
 
         this.listenerTypes.forEach(function (listenerType) {
-            subject.removeEventListener(eventNames[listenerType][event], handler, options);
+            const evt = eventNames[listenerType][event];
+
+            if (evt) {
+                subject.removeEventListener(evt, handler, options);
+            }
         });
     }
 


### PR DESCRIPTION
For example, when `enableMouseEvents` is set, a call is made to `this.addEventListener(window, 'contextmenu', ...)`. This does not exist under the `eventNames.touch` or `eventNames.keyboard`, which in turn causes `subject.addEventListener` to be called with `undefined` as the event name.

Under a Cordova application, this causes the app to hang as it immediately tries to call `.toLowerCase()` on an undefined value. I'd assume this could cause issues elsewhere too!

This commit adds a simple check that the event exists before trying to add/remove handlers.