### PR TITLE
Prevent null pointer error when dragging offscreen in IE

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -28,7 +28,8 @@ const elementsFromPoint = ((typeof document !== 'undefined' && document.elements
 
     if (document.msElementsFromPoint) {
         // msElementsFromPoint is much faster but returns a node-list, so convert it to an array
-        return Array.prototype.slice.call(document.msElementsFromPoint(x, y), 0);
+        const msElements = document.msElementsFromPoint(x, y);
+        return msElements && Array.prototype.slice.call(msElements, 0);
     }
 
     var elements = [], previousPointerEvents = [], current, i, d;


### PR DESCRIPTION
When the (x, y) coordinate passed to `msElementsFromPoint` is offscreen, the function returns null. When this is the case, check null before converting the result to an array to avoid `TypeError: Array.prototype.slice called on null or undefined` error