### PR TITLE
optimize dnd when not dragging

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -249,6 +249,10 @@ export class TouchBackend {
         const handleMove = (e) => {
             let coords;
 
+            if (!this.monitor.isDragging()) {
+                return;
+            }
+
             /**
              * Grab the coordinates for the current mouse/touch position
              */


### PR DESCRIPTION
Don't notify react-dnd of mouse moves when the user isn't dragging, as this creates a ton of potential forced relayouts.