### PR TITLE
Make sure the list of hovered ids is unique.

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -456,7 +456,8 @@ export class TouchBackend {
             return null;
           })
           // Filter off possible null rows
-          .filter(node => !!node);
+          .filter(node => !!node)
+          .filter((id, index, ids) => ids.indexOf(id) === index);
 
         // Reverse order because dnd-core reverse it before calling the DropTarget drop methods
         orderedDragOverTargetIds.reverse();


### PR DESCRIPTION
This fixes an issue where a Drop Target would be returned multiple times
by document.elementsFromPoint(), triggering an invariant violation in
react-dnd because the same target ID would be present multiple times.