### PR TITLE
Fix errors when users mouse down with non-primary button

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -341,7 +341,7 @@ export class TouchBackend {
     handleMoveStart (sourceId) {
         // Just because we received an event doesn't necessarily mean we need to collect drag sources.
         // We only collect start collecting drag sources on touch and left mouse events.
-        if (this.moveStartSourceIds) {
+        if (Array.isArray(this.moveStartSourceIds)) {
             this.moveStartSourceIds.unshift(sourceId);
         }
     }

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -339,7 +339,11 @@ export class TouchBackend {
     }
 
     handleMoveStart (sourceId) {
-        this.moveStartSourceIds.unshift(sourceId);
+        // Just because we received an event doesn't necessarily mean we need to collect drag sources.
+        // We only collect start collecting drag sources on touch and left mouse events.
+        if (this.moveStartSourceIds) {
+            this.moveStartSourceIds.unshift(sourceId);
+        }
     }
 
     getTopMoveStartHandler () {


### PR DESCRIPTION
Fix a undefined reference exception when the user mouses down with center or right mouse button.
handleTopMoveStartCapture doesn't initialize this.moveStartSourceIds if you didn't fire a touch or left mouse button event.