### PR TITLE
Touch improvements

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -145,6 +145,7 @@ export class TouchBackend {
             enableKeyboardEvents: false,
             delayTouchStart: 0,
             delayMouseStart: 0,
+            touchSlop: 0,
             ...options
         };
 
@@ -156,6 +157,7 @@ export class TouchBackend {
         this.enableMouseEvents = options.enableMouseEvents;
         this.delayTouchStart = options.delayTouchStart;
         this.delayMouseStart = options.delayMouseStart;
+        this.touchSlop = options.touchSlop;
         this.sourceNodes = {};
         this.sourceNodeOptions = {};
         this.sourcePreviewNodes = {};
@@ -404,17 +406,13 @@ export class TouchBackend {
             return;
         }
 
-
         // If we're not dragging and we've moved a little, that counts as a drag start
         if (
             !this.monitor.isDragging() &&
             this._mouseClientOffset.hasOwnProperty('x') &&
-            moveStartSourceIds &&
-            (
-                this._mouseClientOffset.x !== clientOffset.x ||
-                this._mouseClientOffset.y !== clientOffset.y
-            )
-        ) {
+            moveStartSourceIds && 
+            distance(this._mouseClientOffset.x, this._mouseClientOffset.y, clientOffset.x, clientOffset.y) >
+                (this.touchSlop ? this.touchSlop : 0)) {
             this.moveStartSourceIds = null;
             this.actions.beginDrag(moveStartSourceIds, {
                 clientOffset: this._mouseClientOffset,
@@ -550,4 +548,8 @@ export default function createTouchBackend (optionsOrManager = {}) {
     } else {
         return touchBackendFactory;
     }
+}
+
+function distance(x1, y1, x2, y2) {
+    return Math.sqrt(Math.pow(Math.abs(x2 - x1), 2) + Math.pow(Math.abs(y2 - y1), 2));
 }

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -143,6 +143,7 @@ export class TouchBackend {
             enableTouchEvents: true,
             enableMouseEvents: false,
             enableKeyboardEvents: false,
+            ignoreContextMenu: false,
             delayTouchStart: 0,
             delayMouseStart: 0,
             touchSlop: 0,
@@ -157,6 +158,7 @@ export class TouchBackend {
         this.enableMouseEvents = options.enableMouseEvents;
         this.delayTouchStart = options.delayTouchStart;
         this.delayMouseStart = options.delayMouseStart;
+        this.ignoreContextMenu = options.ignoreContextMenu;
         this.touchSlop = options.touchSlop;
         this.sourceNodes = {};
         this.sourceNodeOptions = {};
@@ -203,7 +205,7 @@ export class TouchBackend {
         this.addEventListener(window, 'move',       this.handleTopMoveCapture, true);
         this.addEventListener(window, 'end',        this.handleTopMoveEndCapture, true);
 
-        if (this.enableMouseEvents) {
+        if (this.enableMouseEvents && !this.ignoreContextMenu) {
             this.addEventListener(window, 'contextmenu', this.handleTopMoveEndCapture);
         }
 
@@ -226,7 +228,7 @@ export class TouchBackend {
         this.removeEventListener(window, 'move',  this.handleTopMove);
         this.removeEventListener(window, 'end',   this.handleTopMoveEndCapture, true);
 
-        if (this.enableMouseEvents) {
+        if (this.enableMouseEvents && !this.ignoreContextMenu) {
             this.removeEventListener(window, 'contextmenu', this.handleTopMoveEndCapture);
         }
 


### PR DESCRIPTION
Hi there,

This PR represents 2 changes presented as options to avoid breaking changes.

1. Add `touchSlop` option to specify the distance moved before a drag is signaled. This is a standard behavior on native mobile OS's to differentiate between gestures. For example, if the user is attempting to press-and-hold to initiate the context menu in Chrome, it's nearly impossible for their finger to stay _perfectly_ still, and thus they will incorrectly trigger a drag the instant it moves 1 pixel. Requiring them to move X pixels before triggering a drag event fixes this. I set this option to 20 on my implementation, but I honestly think this should be default behavior for this library.
1. Add `ignoreContextMenu` option to stop this library from blocking a drag after the context menu is shown. We wanted to allow the user to long-press and then drag, as well as just a normal drag, because some users expect a drag/drop operation requires a long-press to initiate (which triggers the context menu on Chrome). We wanted to allow this and just dismiss the context menu if they keep dragging. FWIW, I don't think the rationale for this library's current behavior is correct (introduced in https://github.com/yahoo/react-dnd-touch-backend/pull/52), because it was implemented to handle a pretty extreme edge case for mouse users (right-click drag??) at the cost of breaking a more common touch gesture.

I'm happy to tweak these options if requested.