### PR TITLE
Add scrolling touch ranges

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Options include:
 - delayMouseStart
 - touchSlop
 - ignoreContextMenu
+- scrollAngleRanges
 
 ## Tips
 ### Drag Preview
@@ -70,6 +71,21 @@ DragDropContext(TouchBackend({ touchSlop: 20 }));
 ```js
 DragDropContext(TouchBackend({ ignoreContextMenu: true }));
 ```
+
+**scrollAngleRanges**
+
+* Specifies ranges of angles in degrees that drag events should be ignored. This is useful when you want to allow the 
+user to scroll in a particular direction instead of dragging. Degrees move clockwise, 0/360 pointing to the 
+left. 
+* Default: undefined
+```js
+// allow vertical scrolling
+DragDropContext(TouchBackend({ scrollAngleRanges: [{ start: 30, end: 150 }, { start: 210, end: 330 }] }));
+
+// allow horizontal scrolling
+DragDropContext(TouchBackend({ scrollAngleRanges: [{ start: 300 }, { end: 60 }, { start: 120, end: 240 }] }));
+```
+
 
 ## Examples
 The `examples` folder has a sample integration. In order to build it, run:


### PR DESCRIPTION
Adds support for ignoring drag events between specified angles. 

In a lot of use cases it only makes sense to drag an item in a particular direction. E.g. if the drop target is always to the right of the source. In those cases it makes sense to ignore drag events and keep the native scrolling behaviour in other directions.

As an example in production, see the photo panel on www.canva.com:

<img width="1111" alt="instagram_post_ _red_and_white_photo_bake_sale_instagram_post" src="https://user-images.githubusercontent.com/986449/38786704-ef8ea332-416c-11e8-9d81-9d72bbd41173.png">
