### PR TITLE
Include size 0 ancestor elements

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -454,13 +454,12 @@ export class TouchBackend {
         let elementsAtPoint = this.getDropTargetElementsAtPoint
           ? this.getDropTargetElementsAtPoint(clientOffset.x, clientOffset.y, dragOverTargetNodes)
           : elementsFromPoint(clientOffset.x, clientOffset.y);
-        // Extend list with SVG parents that are not receiving elementsFromPoint events (svg groups)
+      // Extend list with parents that are not receiving elementsFromPoint events (size 0 elements and svg groups)
         let elementsAtPointExtended = [];
         for (let nodeId in elementsAtPoint){
             let currentNode = elementsAtPoint[nodeId];
             elementsAtPointExtended.push(currentNode);
-            // Is currentNode an SVG element
-            while(currentNode && currentNode.ownerSVGElement){
+            while(currentNode){
                 currentNode = currentNode.parentElement;
                 if( !elementsAtPointExtended.includes(currentNode) ) elementsAtPointExtended.push(currentNode)
             }


### PR DESCRIPTION
The `HTML5Backend` uses the `dragenter` event that bubbles to all ancestors.
`react-dnd-touch-backend` uses `elementsFromPoint` which does *not* include ancestors.

This causes a difference in behaviour when an ancestor element has no size. E.g.

```
connect(
   <div>
     <div style={{ position: 'absolute', top: 20, left: 20, width: 100, height: 100 }}/>
   </div>
)
```
 
In the above case, `HTML5Backend` will respond to drags over the inner element, but `react-dnd-touch-backend` will not.
