### PR TITLE
Add option for custom getDropTargetElementsAtPoint function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,25 @@ DragDropContext(TouchBackend({ scrollAngleRanges: [{ start: 30, end: 150 }, { st
 DragDropContext(TouchBackend({ scrollAngleRanges: [{ start: 300 }, { end: 60 }, { start: 120, end: 240 }] }));
 ```
 
+**getDropTargetElementsAtPoint**
+* Specify a custom function to find drop target elements at the given point.  Useful for improving performance in environments (iOS Safari) where document.elementsFromPoint is not available.
+* Default: undefined (use document.elementsFromPoint or inline elementsFromPoint "polyfill")
+```js
+const hasNative = document && (document.elementsFromPoint || document.msElementsFromPoint);
+
+function getDropTargetElementsAtPoint(x, y, availableDropTargets) {
+  return dropTargets.filter(t => {
+    const rect = t.getBoundingClientRect();
+    return (x >= rect.left && x <= rect.right && 
+            y <= rect.bottom && y >= rect.top);
+  });
+}
+
+// use custom function only if elementsFromPoint is not supported 
+DragDropContext(TouchBackend({
+  getDropTargetElementsAtPoint: !hasNative && getDropTargetElementsAtPoint,
+}))
+```
 
 ## Examples
 The `examples` folder has a sample integration. In order to build it, run:

--- a/src/Touch.js
+++ b/src/Touch.js
@@ -184,6 +184,10 @@ export class TouchBackend {
             this.listenerTypes.push('keyboard')
         }
 
+        if (options.getDropTargetElementsAtPoint) {
+            this.getDropTargetElementsAtPoint = options.getDropTargetElementsAtPoint;
+        }
+
         this.getSourceClientOffset = this.getSourceClientOffset.bind(this);
         this.handleTopMoveStart = this.handleTopMoveStart.bind(this);
         this.handleTopMoveStartDelay = this.handleTopMoveStartDelay.bind(this);
@@ -447,7 +451,9 @@ export class TouchBackend {
         // Get the node elements of the hovered DropTargets
         const dragOverTargetNodes = dragOverTargetIds.map(key => this.targetNodes[key]);
         // Get the a ordered list of nodes that are touched by
-        let elementsAtPoint = elementsFromPoint(clientOffset.x, clientOffset.y);
+        let elementsAtPoint = this.getDropTargetElementsAtPoint
+          ? this.getDropTargetElementsAtPoint(clientOffset.x, clientOffset.y, dragOverTargetNodes)
+          : elementsFromPoint(clientOffset.x, clientOffset.y);
         // Extend list with SVG parents that are not receiving elementsFromPoint events (svg groups)
         let elementsAtPointExtended = [];
         for (let nodeId in elementsAtPoint){


### PR DESCRIPTION
This is primarily useful for improving performance on iOS Safari and any environment that doesn't support document.elementsFromPoint, because the performance of the elementsFromPoint inline "polyfill" is bad.

Fix for #88.