### PR TITLE
Fix console errors on hitting Escape button

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -509,7 +509,7 @@ export class TouchBackend {
     }
 
     handleCancelOnEscape (e) {
-        if (e.key === 'Escape'){
+        if (e.key === 'Escape' && this.monitor.isDragging()){
             this._mouseClientOffset = {};
 
             this.uninstallSourceNodeRemovalObserver();


### PR DESCRIPTION
This PR solves #108.

Now console doesn't throw the error on hitting `Escape` button