### PR TITLE
Do not use Array.includes because it is not supported in ie11

### DIFF
--- a/src/Touch.js
+++ b/src/Touch.js
@@ -464,7 +464,7 @@ export class TouchBackend {
             elementsAtPointExtended.push(currentNode);
             while (currentNode){
                 currentNode = currentNode.parentElement;
-                if ( !elementsAtPointExtended.includes(currentNode) ) {elementsAtPointExtended.push(currentNode)}
+                if ( elementsAtPointExtended.indexOf(currentNode) === -1 ) {elementsAtPointExtended.push(currentNode)}
             }
         }
         let orderedDragOverTargetIds = elementsAtPointExtended


### PR DESCRIPTION
Array.includes is not supported by ie11 see: https://caniuse.com/#feat=array-includes

Project itself is supporting ie >= 11, see: https://github.com/yahoo/react-dnd-touch-backend/blob/master/.babelrc#L12

